### PR TITLE
[refactor/yezzero] recruitmentsCreate / myApplyStatus / projectDetail / projectEdit 페이지

### DIFF
--- a/app/user/projects/[id]/_components/applicantDetails.tsx
+++ b/app/user/projects/[id]/_components/applicantDetails.tsx
@@ -4,6 +4,8 @@ import styles from "../projectDetail.module.scss";
 
 import type { ProjectDetailApplyDto } from "@/application/usecases/project/dtos/projectDetailApplyDto";
 
+import { POSITION_MAP } from "./membersSection";
+
 interface ApplicantDetailsProps {
   applicant: ProjectDetailApplyDto;
 }
@@ -16,7 +18,7 @@ const ApplicantDetails = ({ applicant }: ApplicantDetailsProps) => {
       {Object.entries({
         이름: applicant.user?.name,
         생년월일: applicant.user?.birthDate,
-        직무: applicant.user?.position,
+        직무: applicant.user?.position ? POSITION_MAP[applicant.user?.position] : "직무 없음",
         성별: applicant.user?.gender,
         거주지: applicant.user?.address,
         경력: `${applicant.user?.career}년`,

--- a/app/user/projects/[id]/_components/applicationsSection.tsx
+++ b/app/user/projects/[id]/_components/applicationsSection.tsx
@@ -54,9 +54,10 @@ export default function ApplicationsSection({
     }
   };
 
-  const transformedApplications = applications?.map((app) => ({
-    ...app,
-    user: typeof app.user === "object" ? app.user.name : app.user,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const transformedApplications = applications?.map(({ createdAt, ...rest }) => ({
+    ...rest,
+    user: typeof rest.user === "object" ? rest.user.name : rest.user,
   }));
 
   return (

--- a/app/user/projects/[id]/_components/membersSection.tsx
+++ b/app/user/projects/[id]/_components/membersSection.tsx
@@ -4,7 +4,17 @@ import Table from "@/components/table/table";
 
 import styles from "../projectDetail.module.scss";
 
+import { POSITION_OPTIONS } from "@/constants/selectOptions";
+
 import type { ProjectDetailMemberDto } from "@/application/usecases/project/dtos/projectDetailMemberDto";
+
+export const POSITION_MAP = POSITION_OPTIONS.reduce(
+  (acc, option) => {
+    acc[option.value] = option.label;
+    return acc;
+  },
+  {} as Record<string, string>,
+);
 
 interface MembersSectionProps {
   members: ProjectDetailMemberDto[] | null;
@@ -17,7 +27,7 @@ export default function MembersSection({ members, leaderId }: MembersSectionProp
 
     return {
       ...mem,
-      position: typeof mem.user === "object" ? mem.user.position : mem.user,
+      position: typeof mem.user === "object" ? POSITION_MAP[mem.user.position] || "직무 없음" : mem.user,
       user: typeof mem.user === "object" ? `${mem.user.name}${isLeader ? " 👑" : ""}` : mem.user,
     };
   });

--- a/app/user/projects/[id]/_components/noticeSection.tsx
+++ b/app/user/projects/[id]/_components/noticeSection.tsx
@@ -2,8 +2,6 @@
 
 import { useState } from "react";
 
-import InputField from "@/components/inputField/inputField";
-
 import styles from "../projectDetail.module.scss";
 
 interface NoticeSectionProps {
@@ -36,7 +34,12 @@ export default function NoticeSection({ notice, updateNotice, userRole }: Notice
       </div>
 
       {isNoticeEdit ? (
-        <InputField value={noticeContent} onChange={(e) => setNoticeContent(e.target.value)} />
+        <textarea
+          className={styles.noticeTextarea}
+          value={noticeContent}
+          onChange={(e) => setNoticeContent(e.target.value)}
+          rows={4}
+        />
       ) : (
         <p>{noticeContent}</p>
       )}

--- a/app/user/projects/[id]/edit/page.tsx
+++ b/app/user/projects/[id]/edit/page.tsx
@@ -80,7 +80,12 @@ export default function EditProject() {
       }
 
       alert("프로젝트 수정이 완료되었습니다.");
-      router.back();
+
+      if (window.history.length > 2) {
+        window.history.go(-2);
+      } else {
+        router.push("/user/information");
+      }
     } catch (err) {
       console.error("❌ 프로젝트 수정 오류:", err);
       alert("프로젝트 수정 중 오류가 발생했습니다.");

--- a/app/user/projects/[id]/edit/page.tsx
+++ b/app/user/projects/[id]/edit/page.tsx
@@ -53,6 +53,13 @@ export default function EditProject() {
     extensions: [StarterKit, Underline, TextStyle, Heading.configure({ levels: [1, 2, 3] })],
     content: "",
     onUpdate: ({ editor }) => setDescription(editor.getHTML()),
+    editorProps: {
+      handleDOMEvents: {
+        beforeinput: () => false, // Next.js Hydration 오류 방지
+      },
+    },
+    injectCSS: false, // CSS 관련 Hydration 방지
+    immediatelyRender: false, // Hydration 오류 방지
   });
 
   /* ---------------------------------- 이벤트 핸들러 --------------------------------- */

--- a/app/user/projects/[id]/page.tsx
+++ b/app/user/projects/[id]/page.tsx
@@ -107,7 +107,7 @@ export default function ProjectDetail() {
 
       alert("프로젝트 나가기에 성공했습니다.");
 
-      setTimeout(() => setRefresh((prev) => !prev), 100);
+      setTimeout(() => router.push("/recruitments"), 100);
     } catch (error) {
       console.error("❌ 프로젝트 나가기 실패.", error);
       alert("프로젝트 나가기 중 오류가 발생했습니다.");
@@ -129,7 +129,7 @@ export default function ProjectDetail() {
 
       alert("프로젝트 삭제에 성공했습니다.");
 
-      setTimeout(() => router.push("/user/information"), 100);
+      setTimeout(() => router.push("/user/projects/myOpen"), 100);
     } catch (error) {
       console.error("❌ 프로젝트 삭제 실패.", error);
       alert("프로젝트 삭제 중 오류가 발생했습니다.");
@@ -211,7 +211,7 @@ export default function ProjectDetail() {
   if (userRole === "guest") {
     return <div className={styles.error}>❌ 접근 권한이 없습니다.</div>;
   }
-  if (userRole === "realGuest") {
+  if (!loading && userRole === "realGuest") {
     return <div className={styles.error}>❌ 토큰이 유효하지 않습니다.</div>;
   }
 

--- a/app/user/projects/[id]/page.tsx
+++ b/app/user/projects/[id]/page.tsx
@@ -227,7 +227,7 @@ export default function ProjectDetail() {
       <div className={styles.container__title}>
         <h1>{project.projectTitle}</h1>
         {userRole === "leader" && (
-          <div className={styles.container__title___buttons}>
+          <div className={styles.container__title__buttons}>
             <button type="button" onClick={handleEdit}>
               수정
             </button>

--- a/app/user/projects/[id]/projectDetail.module.scss
+++ b/app/user/projects/[id]/projectDetail.module.scss
@@ -184,7 +184,7 @@
   margin: 10px 0;
   display: flex;
   justify-content: space-around;
-  gap: 10px;
+  gap: 15px;
 
   button {
     cursor: pointer;

--- a/app/user/projects/[id]/projectDetail.module.scss
+++ b/app/user/projects/[id]/projectDetail.module.scss
@@ -81,6 +81,31 @@
     max-width: 100%;
     word-break: break-word;
   }
+
+  .noticeTextarea {
+    max-width: 100%;
+    min-height: 80px;
+    padding: 8px;
+    font-size: 14px;
+    line-height: 1.6;
+    border: 1px solid $color-dark-gray;
+    border-radius: 4px;
+    resize: none;
+
+    &::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background-color: $color-light-gray;
+      border-radius: 4px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+  }
 }
 
 .container__row_2 {

--- a/app/user/projects/[id]/projectDetail.module.scss
+++ b/app/user/projects/[id]/projectDetail.module.scss
@@ -49,11 +49,20 @@
 
   &__buttons {
     font-size: 12px;
+
+    button {
+      color: $color-black;
+      transition: color 0.2s ease;
+      &:hover {
+        color: $color-main;
+      }
+    }
   }
 }
 
 .container__content {
   flex: 1;
+  min-width: calc(50% - 7.5px);
   padding: 15px;
   display: flex;
   flex-direction: column;
@@ -69,6 +78,8 @@
 
   p {
     font-size: 14px;
+    max-width: 100%;
+    word-break: break-word;
   }
 }
 

--- a/app/user/recruitments/(handle)/create/_components/createTags/createTags.module.scss
+++ b/app/user/recruitments/(handle)/create/_components/createTags/createTags.module.scss
@@ -1,11 +1,14 @@
 .create {
   &__tag-container {
     display: flex;
+    height: auto;
+    align-items: stretch;
     gap: 16px;
     margin-bottom: 12px;
   }
 
   &__tag-input {
+    flex: 2;
     display: flex;
     align-items: center;
     border: 1px solid $color-solid-line;
@@ -29,7 +32,7 @@
     all: unset;
     font-size: 14px;
     min-width: 0;
-    width: 180px
+    width: 180px;
   }
 
   &__tag-input input::placeholder {
@@ -61,13 +64,13 @@
     font-size: 10px;
   }
   &__tag-reset {
+    flex: 0.1;
     background: white;
     color: black;
-    border: 1px solid $color-light-gray;
+    border: 1px solid $color-solid-line;
     padding: 0px 21px;
     border-radius: 4px;
     cursor: pointer;
     font-size: 14px;
-    height: 49px;
   }
 }

--- a/app/user/recruitments/(handle)/create/page.tsx
+++ b/app/user/recruitments/(handle)/create/page.tsx
@@ -69,6 +69,13 @@ export default function Create() {
       <p>📢 사전 공지사항 :</p>
     `,
     onUpdate: ({ editor }) => setDescription(editor.getHTML()),
+    editorProps: {
+      handleDOMEvents: {
+        beforeinput: () => false, // Next.js Hydration 오류 방지
+      },
+    },
+    injectCSS: false, // CSS 관련 Hydration 방지
+    immediatelyRender: false, // Hydration 오류 방지
   });
 
   /* ---------------------------------- event handler --------------------------------- */

--- a/app/user/recruitments/(handle)/create/page.tsx
+++ b/app/user/recruitments/(handle)/create/page.tsx
@@ -37,7 +37,13 @@ export default function Create() {
     goal: "",
   });
 
-  const [description, setDescription] = useState("내용 없음");
+  const [description, setDescription] = useState(`
+    <p>🗺️ 프로젝트를 진행할 지역 :</p>
+    <p>🌱 모집 요건(인원수, 기술스택 등) :</p>
+    <p>📞 지원 방법 (이메일, 카카오 오픈채팅방, 구글폼 등) :</p>
+    <p>😆 팀원은 이런 사람이였으면 좋겠어요 :</p>
+    <p>📢 사전 공지사항 :</p>
+  `);
   const [projectPeriod, setProjectPeriod] = useState<SelectionRange[]>([
     { startDate: new Date(), endDate: new Date(), key: "selection" },
   ]);
@@ -79,14 +85,12 @@ export default function Create() {
     const requestBody = {
       ...projectData,
       description,
-      projectPeriodStart: projectPeriod[0].startDate ? new Date(projectPeriod[0].startDate) : null, // ✅ 변환
-      projectPeriodEnd: projectPeriod[0].endDate ? new Date(projectPeriod[0].endDate) : null, // ✅ 변환
-      recruitmentStart: recruitmentPeriod[0].startDate ? new Date(recruitmentPeriod[0].startDate) : null, // ✅ 변환
-      recruitmentEnd: recruitmentPeriod[0].endDate ? new Date(recruitmentPeriod[0].endDate) : null, // ✅ 변환
+      projectPeriodStart: projectPeriod[0].startDate ? new Date(projectPeriod[0].startDate) : null,
+      projectPeriodEnd: projectPeriod[0].endDate ? new Date(projectPeriod[0].endDate) : null,
+      recruitmentStart: recruitmentPeriod[0].startDate ? new Date(recruitmentPeriod[0].startDate) : null,
+      recruitmentEnd: recruitmentPeriod[0].endDate ? new Date(recruitmentPeriod[0].endDate) : null,
       projectTags: tags,
     };
-
-    console.log("📢 요청 데이터:", requestBody); // ✅ 요청 데이터 확인
 
     try {
       const response = await fetch("/api/project/1", {

--- a/app/user/recruitments/(my)/myApplyStatus/_components/myApplyStatusItem.tsx
+++ b/app/user/recruitments/(my)/myApplyStatus/_components/myApplyStatusItem.tsx
@@ -65,7 +65,7 @@ export default function MyApplyStatusItem({
             <span className={styles["myapplystatusitem__post-author"]}>{apply.project?.leader?.nickname}</span>
             <span className={styles["myapplystatusitem__post-dot"]}>·</span>
             <span className={styles["myapplystatusitem__post-date"]}>
-              {apply.project?.createdAt !== undefined ? formatDateTime(new Date(apply.project.createdAt)) : "값 없음"}
+              {apply.createdAt !== undefined ? formatDateTime(new Date(apply.createdAt)) : "값 없음"}
             </span>
           </div>
           <div className={styles["myapplystatusitem__post-stats"]}>

--- a/app/user/recruitments/(my)/myApplyStatus/myApplyStatus.module.scss
+++ b/app/user/recruitments/(my)/myApplyStatus/myApplyStatus.module.scss
@@ -64,7 +64,7 @@
   margin: 15px 10px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 15px;
 
   &_item {
     display: flex;

--- a/app/user/recruitments/(my)/myApplyStatus/page.tsx
+++ b/app/user/recruitments/(my)/myApplyStatus/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 
 import Modal from "@/components/modal/modal";
+import { POSITION_MAP } from "@/app/user/projects/[id]/_components/membersSection";
 
 import { decodeToken } from "@/utils/cookie";
 import { formatDateToString } from "@/utils/formatDateToString";
@@ -130,7 +131,7 @@ export default function Page() {
 
       {/* 데이터가 없을 경우 */}
       {!loading && !error && applyStatusData.length === 0 && (
-        <p className={styles["myapplystatus__empty"]}>내역이 없습니다.</p>
+        <p className={styles["myapplystatus__empty"]}>나의 신청현황이 없습니다.</p>
       )}
 
       {/* 데이터 렌더링 */}
@@ -150,7 +151,7 @@ export default function Page() {
             {Object.entries({
               이름: selectedApply.user?.name,
               생년월일: selectedApply.user?.birthDate,
-              직무: selectedApply.user?.position,
+              직무: selectedApply.user?.position ? POSITION_MAP[selectedApply.user?.position] : "직무 없음",
               성별: selectedApply.user?.gender,
               거주지: selectedApply.user?.address,
               경력: `${selectedApply.user?.career}년`,

--- a/app/user/recruitments/(my)/myApplyStatus/page.tsx
+++ b/app/user/recruitments/(my)/myApplyStatus/page.tsx
@@ -139,6 +139,7 @@ export default function Page() {
         !error &&
         applyStatusData
           .filter((item) => activeFilter === "전체" || item.status === activeFilter)
+          .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
           .map((item) => (
             <MyApplyStatusItem key={item.id} apply={item} handleModal={handleModal} handleClick={handleClick} />
           ))}

--- a/application/usecases/dtos/applyDto.ts
+++ b/application/usecases/dtos/applyDto.ts
@@ -6,4 +6,5 @@ export interface ApplyDto {
   introduction: string;
   portfolioUrl: string | null;
   status: string;
+  createdAt: Date;
 }

--- a/application/usecases/project/getProjectDetailUsecase.ts
+++ b/application/usecases/project/getProjectDetailUsecase.ts
@@ -68,6 +68,7 @@ export class GetProjectDetailUsecase {
             introduction: apply.introduction,
             portfolioUrl: apply.portfolioUrl,
             status: apply.status,
+            createdAt: apply.createdAt,
             user: apply.user
               ? {
                 ...apply.user,

--- a/application/usecases/project/rejectApplicantUsecase.ts
+++ b/application/usecases/project/rejectApplicantUsecase.ts
@@ -18,7 +18,7 @@ export class RejectApplicantUsecase {
       if (!applicantData) return null;
 
       // 지원 상태를 "reject"로 변경
-      const updatedApply = await this.applyRepository.updateStatus(id, "REJECT");
+      const updatedApply: ApplyDto = await this.applyRepository.updateStatus(id, "REJECT");
 
       // 지원자 정보를 찾음
       const userData = await this.userRepository.findById(applicantData.userId);
@@ -35,6 +35,7 @@ export class RejectApplicantUsecase {
         introduction: updatedApply.introduction,
         portfolioUrl: updatedApply.portfolioUrl,
         status: updatedApply.status,
+        createdAt: updatedApply.createdAt,
         user: filteredUserData,
       };
     } catch (error) {

--- a/application/usecases/recruitment/dtos/ApplyInputDto.ts
+++ b/application/usecases/recruitment/dtos/ApplyInputDto.ts
@@ -1,5 +1,5 @@
 import type { ApplyDto } from "../../dtos/applyDto";
 
-export interface ApplyInputDto extends Omit<ApplyDto, "portfolioUrl" | "status" | "id"> {
+export interface ApplyInputDto extends Omit<ApplyDto, "portfolioUrl" | "status" | "id" | "createdAt"> {
   portfolioFile?: File | null;
 }

--- a/application/usecases/recruitment/getMyApplyStatusUsecase.ts
+++ b/application/usecases/recruitment/getMyApplyStatusUsecase.ts
@@ -38,6 +38,7 @@ export class GetMyApplyStatusUsecase {
           introduction: app.introduction,
           portfolioUrl: app.portfolioUrl,
           status: app.status === "WAITING" ? "수락대기" : app.status === "ACCEPT" ? "수락됨" : "거절됨",
+          createdAt: app.createdAt,
           project: app.project,
           user: app.user
             ? {

--- a/components/table/table.tsx
+++ b/components/table/table.tsx
@@ -22,11 +22,11 @@ interface TableProps {
 export const renderCell = (key: string, value: string | number | ReactNode, onFormClick?: (id: number) => void) => {
   if (key === "status") {
     const statusClass =
-      value === "accept" ? styles.statusAccepted : value === "reject" ? styles.statusRejected : styles.statusWaiting;
+      value === "ACCEPT" ? styles.statusAccepted : value === "REJECT" ? styles.statusRejected : styles.statusWaiting;
 
     return (
       <span className={`${styles.status} ${statusClass}`}>
-        {value === "accept" ? "수락됨" : value === "reject" ? "거절됨" : "대기 중"}
+        {value === "ACCEPT" ? "수락됨" : value === "REJECT" ? "거절됨" : "대기 중"}
       </span>
     );
   }

--- a/domain/repositories/applyRepository.ts
+++ b/domain/repositories/applyRepository.ts
@@ -6,5 +6,5 @@ export interface ApplyRepository {
   findByUserProject(userId: string, projectId: number): Promise<Apply | null>;
   updateStatus(id: number, status: string): Promise<Apply>;
   delete(id: number): Promise<void>;
-  create(applyData: Omit<Apply, "id" | "status">): Promise<Apply>;
+  create(applyData: Omit<Apply, "id" | "status" | "createdAt">): Promise<Apply>;
 }

--- a/infrastructure/repositories/psApplyRepository.ts
+++ b/infrastructure/repositories/psApplyRepository.ts
@@ -91,7 +91,7 @@ export class PsApplyRepository implements ApplyRepository {
     }
   }
 
-  async create(applyData: Omit<Apply, "id" | "status">): Promise<Apply> {
+  async create(applyData: Omit<Apply, "id" | "status" | "createdAt">): Promise<Apply> {
     try {
       const apply = await prisma.apply.create({
         data: applyData,

--- a/infrastructure/repositories/psTagRepository.ts
+++ b/infrastructure/repositories/psTagRepository.ts
@@ -62,21 +62,43 @@ export class PsTagRepository implements TagRepository {
   }
   async addTags(tagNames: string[]): Promise<Tag[]> {
     try {
-      await prisma.tag.createMany({
-        data: tagNames.map((tagName) => ({ tagName })),
-      });
-      return await prisma.tag.findMany({
+      // 기존 태그 조회 (이미 존재하는 태그 찾기)
+      const existingTags = await prisma.tag.findMany({
         where: {
-          tagName: {
-            in: tagNames,
-          },
+          tagName: { in: tagNames },
+        },
+        select: {
+          id: true,
+          tagName: true,
         },
       });
+
+      // 존재하는 태그의 이름을 배열로 저장
+      const existingTagNames = new Set(existingTags.map((tag) => tag.tagName));
+
+      // 새로운 태그 찾기 (이미 존재하는 태그를 제외)
+      const newTagNames = tagNames.filter((tagName) => !existingTagNames.has(tagName));
+
+      // 새로운 태그 생성 (필요한 경우)
+      if (newTagNames.length > 0) {
+        await prisma.tag.createMany({
+          data: newTagNames.map((tagName) => ({ tagName })),
+          skipDuplicates: true, // 중복 태그 생성을 방지
+        });
+      }
+
+      // 최종적으로 모든 태그를 조회하여 반환
+      const allTags = await prisma.tag.findMany({
+        where: {
+          tagName: { in: tagNames },
+        },
+      });
+
+      console.log("추가된 태그들:", allTags);
+      return allTags;
     } catch (error) {
       console.error("태그 추가 중 오류 발생:", error);
       throw new Error("태그를 추가하는 데 실패했습니다.");
-    } finally {
-      await prisma.$disconnect();
     }
   }
 

--- a/utils/formatDateTime.ts
+++ b/utils/formatDateTime.ts
@@ -1,10 +1,12 @@
-export const formatDateTime = (date: Date): string => {
-  const newDate = new Date(date);
-  const year = newDate.getFullYear().toString().slice(2); // 두 자리 연도
-  const month = String(newDate.getMonth() + 1).padStart(2, "0");
-  const day = String(newDate.getDate()).padStart(2, "0");
-  const hours = String(newDate.getHours()).padStart(2, "0");
-  const minutes = String(newDate.getMinutes()).padStart(2, "0");
+export const formatDateTime = (date: Date | string): string => {
+  const utcDate = new Date(date);
+  const kstDate = new Date(utcDate.getTime() - 9 * 60 * 60 * 1000); // UTC → KST 변환
+
+  const year = kstDate.getFullYear().toString().slice(2); // 두 자리 연도
+  const month = String(kstDate.getMonth() + 1).padStart(2, "0");
+  const day = String(kstDate.getDate()).padStart(2, "0");
+  const hours = String(kstDate.getHours()).padStart(2, "0");
+  const minutes = String(kstDate.getMinutes()).padStart(2, "0");
 
   return `${year}.${month}.${day}. ${hours}:${minutes}`;
 };

--- a/utils/formatDateToString.ts
+++ b/utils/formatDateToString.ts
@@ -1,4 +1,6 @@
-export const formatDateToString = (date: Date): string => {
-  const newDate = new Date(date);
-  return `${newDate.getFullYear()}년 ${newDate.getMonth() + 1}월 ${newDate.getDate()}일`;
+export const formatDateToString = (date: Date | string): string => {
+  const utcDate = new Date(date);
+  const kstDate = new Date(utcDate.getTime() - 9 * 60 * 60 * 1000);
+
+  return `${kstDate.getFullYear()}년 ${kstDate.getMonth() + 1}월 ${kstDate.getDate()}일`;
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> ex) #이슈번호, #이슈번호
Resolves #124 

## 📝 작업 내용
- Apply 테이블에 createdAt을 추가함으로써 생기는 오류 수정
- 맡은 페이지에서 고쳐야 할 것들 구현

**모집글 작성 페이지**

- [x] 모집내용 템플릿 그대로 저장할 수 있도록 하기


**프로젝트 수정 페이지**

- [x] Tiptap 에러
- [x] 태그 input, button 높이 간격 맞추기
- [x] 태그 오류 수정
- [x] 수정 완료 후 route 조건문 추가


**프로젝트 상세 페이지**

- [x] 첫 로딩 시 토큰 오류 메세지 제어하기
- [x] 탈퇴 시 리다이렉트를 메인 페이지로 수정
- [x] 멤버 테이블에 직무를 label로 수정
- [x] 신청 현황에 상태(대기중, 승낙, 거절) 맞게 수정
- [x] 공지사항 input -> textarea로 바꾸기
- [x] 공지사항 높이, 텍스트 줄바꿈 넣기
- [x] 프로젝트 삭제하면 myOpen으로 리다이렉트

**내정보/ 신청 현황**

- [x] 리스트 정렬 오름차순으로 수정
- [x] 지원서 createdAt 사용해서 일자 넣기
- [x] 지원서 모달 gap 15px로 바꾸기
- [x] 지원서 모달 직무 label로 수정